### PR TITLE
Removed quotes from bool value

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ https://gohugo.io/hugo-modules/theme-components/.
 Here is an usage example:
 
 ```
-{{< gallery match="images/*" sortOrder="desc" rowHeight="150" margins="5" resizeOptions="600x300 q90 Lanczos" showExif="true" previewType="blur" embedPreview="true" >}}
+{{< gallery match="images/*" sortOrder="desc" rowHeight="150" margins="5" resizeOptions="600x300 q90 Lanczos" showExif=true previewType="blur" embedPreview="true" >}}
 ```
 
 This shortcode will generate a gallery containing all images of the folder *images*.
@@ -76,7 +76,7 @@ The setting `lastRow` configures the justification of the last row of the grid. 
 
 When the users clicks on an image, a lightbox shows up displaying the clicked image in large using the whole available space.
 If the image contains a title or description there will be a top bar displaying that.
-If the `showExif` option is set to "true", some parts of the image's EXIF data will be shown on the bottom bar e.g.: "Canon EOS 80D + EF100-400mm f/4.5-5.6L IS II USM 400mm f/8 1/400sec ISO 2500".
+If the `showExif` option is set to `true` (without quotes), some parts of the image's EXIF data will be shown on the bottom bar e.g.: "Canon EOS 80D + EF100-400mm f/4.5-5.6L IS II USM 400mm f/8 1/400sec ISO 2500".
 The EXIF display will only work if you add following lines to your *config.toml*:
 ```TOML
 [imaging.exif]


### PR DESCRIPTION
Funny thing is it works with quotes as well if "true" *but not if "false*"*.
Without quotes it works in **both cases** and if set to `false` (without quotes) the lower bar under the picture finally displays nothing.