### PR TITLE
Fix issue #27 by making each galleryId globaly unique

### DIFF
--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -81,8 +81,8 @@
 Ordinal increases every time this shortcode is used in a document
 Ordinal: {{ .Ordinal}}
 -->
-{{ $galleryId := (printf "gallery-%v" .Ordinal)}}
-{{ $galleryWrapperId := (printf "gallery-%v-wrapper" .Ordinal)}}
+{{ $galleryId := (printf "gallery-%v-%v" .Page.File.UniqueID .Ordinal)}}
+{{ $galleryWrapperId := (printf "gallery-%v-%v-wrapper" .Page.File.UniqueID .Ordinal)}}
 
 <div id="{{ $galleryWrapperId }}" class="gallery-wrapper">
 <div id="{{ $galleryId }}" class="justified-gallery">


### PR DESCRIPTION
The id of the gallery was the same on multiple pages, this caused issues (second gallery not rendered) on overview pages that show the content of multiple pages at once.

To fix this, the id is now globaly unique by using the hash of the file of the page.