### PR TITLE
Use image .Title as alt tag, if .ImageDescription is not given.

### DIFF
--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -188,6 +188,10 @@ Ordinal: {{ .Ordinal}}
 						{{ with $metadata }}
 							{{ if .ImageDescription }}
 								alt="{{ .ImageDescription }}"
+					     		{{ else }}
+								{{ if .Title}}
+									alt="{{ .Title }}"
+								{{ end }}
 							{{ end }}
 						{{ end }}
 					>


### PR DESCRIPTION
Slight change to avoud empty alt tags whiout .ImageDescription. Thanks for this project, it works wonders!