### PR TITLE
Loop over supported images, excluding avif

### DIFF
--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -85,11 +85,12 @@ Ordinal: {{ .Ordinal}}
 -->
 {{ $galleryId := (printf "gallery-%v-%v" .Page.File.UniqueID .Ordinal)}}
 {{ $galleryWrapperId := (printf "gallery-%v-%v-wrapper" .Page.File.UniqueID .Ordinal)}}
+{{ $supportedFormats := .Site.Params.supportedImageThumbnails | default (slice "jpeg" "png" "tiff" "bmp" "gif") }}
 
 <div id="{{ $galleryWrapperId }}" class="gallery-wrapper">
 <div id="{{ $galleryId }}" class="justified-gallery">
 	{{ range $original := sort $images "Name" $sortOrder}}
-		{{ if eq $original.ResourceType "image" }}
+		{{ if and (eq $original.ResourceType "image") (in $supportedFormats $original.MediaType.SubType) }}
 		
 			{{/* Get metadata from sidecar file, if present. Else an empty dictionary is used. */}}	
 			{{ $metaFileName := print $original.Name ".meta"}}


### PR DESCRIPTION
I have the side script that I run before the build process, which generates `avif` and `webp` images.
Now with this condition, there will be no error in case the `avif` or `webp` images in source directory - they will be just ignored.