### PR TITLE
Fix go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mfg92/hugo-shortcode-gallery
 
-go 1.21.6
+go 1.18


### PR DESCRIPTION
The version in `go.mod` is not compatible with Go module versioning.