### PR TITLE
Implement CSP best practices to prevent XSS

### DIFF
--- a/assets/shortcode-gallery/gallery.js
+++ b/assets/shortcode-gallery/gallery.js
@@ -7,24 +7,30 @@ if (!("HSCGjQuery" in window)) {
   window.HSCGjQuery = window.jQuery.noConflict(true);
 }
 
+// Isolate all our variables from other scripts.
+// See: https://www.nicoespeon.com/en/2013/05/properly-isolate-variables-in-javascript/
+// We also expect to get jQuery as a parameter, so that if a second instance of jQuery is loaded
+// after this script is executed (e.g. by a Hugo theme), we will still be referencing the previous
+// version of jQuery that has all our plugins loaded.
 (function ($) {
   window.hugoShortcodeGallery = {
     init: function (options) {
-      const wrapper = $("#" + options.galleryWrapperId);
       const gallery = $("#" + options.galleryId);
+      const wrapper = $("#" + options.galleryWrapperId);
 
-      // the instance of swipebox, it will be set once justifiedGallery is initialized
+      // The instance of swipebox, it will be set once justifiedGallery is initialized.
       let swipeboxInstance = null;
 
-      // before the gallery initialization the listener has to be added
-      // else we can get a race condition and the listener is never called
+      // Before the gallery initialization, the listener has to be added,
+      // else we can get a race condition and the listener is never called.
       gallery.on("jg.complete", () => {
+        // If there is already some low-resolution image data loaded, then we will wait for loading
+        // the hi-res until the justified gallery has done the layout.
         if (options.previewType === "blur" || options.previewType === "color") {
-          $(() => {
-            gallery.find(".lazy").Lazy({
-              visibleOnly: true,
-              afterLoad: (element) => element.removeClass("lazy-blur"),
-            });
+          gallery.find(".lazy").Lazy({
+            visibleOnly: true,
+            // The class lazy-blur is removed, so the blur filter is removed.
+            afterLoad: (element) => element.removeClass("lazy-blur"),
           });
         }
 
@@ -33,7 +39,7 @@ if (!("HSCGjQuery" in window)) {
           .swipebox($.extend({}, options.swipeboxParameters));
       });
 
-      // initialize the justified gallery
+      // Initialize the justified gallery.
       gallery.justifiedGallery(
         $.extend(
           {
@@ -44,6 +50,9 @@ if (!("HSCGjQuery" in window)) {
             waitThumbnailsLoad: false,
             lastRow: options.lastRow,
             captions: false,
+            // If there is at least one filter option, we first show no images at all
+            // until the code way below selects a filter and applies it.
+            // This prevents creating the layout twice.
             filter:
               options.filterOptions && options.filterOptions.length > 0
                 ? () => false
@@ -53,9 +62,10 @@ if (!("HSCGjQuery" in window)) {
         )
       );
 
+      // Only include JS code for filter options if there is at least one filter option.
       if (options.filterOptions && options.filterOptions.length > 0) {
-        // this function can be used to create a function that can be used by justifiedGallery
-        // for filtering images by their metadata
+        // This function can be used to create a function that can be used by justifiedGallery
+        // for filtering images by their metadata.
         function createMetadataFilter(filterFunction) {
           return (entry, index, array) => {
             let meta = $(entry).find("a").attr("data-meta");
@@ -63,16 +73,16 @@ if (!("HSCGjQuery" in window)) {
 
             let include = filterFunction(meta);
 
-            // only those images visible in justified gallery should be displayed
-            // in swipebox (only <a> with class galleryImg are displayed in swipebox)
+            // Only those images visible in justified gallery should be displayed
+            // in swipebox (only <a> with class galleryImg are displayed in swipebox).
             $(entry).find("a").toggleClass("galleryImg", include);
 
             return include;
           };
         }
 
-        // this function returns a function that can be used by justifiedGallery
-        // for filtering images by their tags
+        // This function returns a function that can be used by justifiedGallery
+        // for filtering images by their tags.
         function createTagFilter(tagsRegexString) {
           const tagsRegex = RegExp(tagsRegexString);
           return createMetadataFilter((meta) => {
@@ -82,8 +92,8 @@ if (!("HSCGjQuery" in window)) {
           });
         }
 
-        // this function returns a function that can be used by justifiedGallery
-        // for filtering images by their description
+        // This function returns a function that can be used by justifiedGallery
+        // for filtering images by their description.
         function createImageDescriptionFilter(descriptionRegexString) {
           const descriptionRegex = RegExp(descriptionRegexString);
           return createMetadataFilter((meta) => {
@@ -95,8 +105,8 @@ if (!("HSCGjQuery" in window)) {
           });
         }
 
-        // this function returns a function that can be used by justifiedGallery
-        // for filtering images by their star rating
+        // This function returns a function that can be used by justifiedGallery
+        // for filtering images by their star rating.
         function createRatingFilter(min, max) {
           return createMetadataFilter((meta) => {
             let rating = meta.Rating;
@@ -107,8 +117,8 @@ if (!("HSCGjQuery" in window)) {
           });
         }
 
-        // this function returns a function that can be used by justifiedGallery
-        // for filtering images by their color labels
+        // This function returns a function that can be used by justifiedGallery
+        // for filtering images by their color labels.
         function createColorLabelFilter(color) {
           color = color.charAt(0).toLowerCase();
           return createMetadataFilter((meta) => {
@@ -117,23 +127,23 @@ if (!("HSCGjQuery" in window)) {
           });
         }
 
-        // insert a div for inserting filter buttons before the gallery
+        // Insert a div for inserting filter buttons before the gallery.
         const filterBar = $("<div class='justified-gallery-filterbar'/>");
         gallery.before(filterBar);
 
         function setFulltab(activate) {
           if (activate == wrapper.hasClass("fulltab")) {
-            return; // nothing to do, we are already in the right state
+            return; // Nothing to do, we are already in the right state.
           }
 
           wrapper.toggleClass("fulltab");
           gallery.justifiedGallery({
             rowHeight: options.rowHeight * (activate ? 1.5 : 1.0),
             lastRow: activate ? "nojustify" : options.lastRow,
-            // force justifiedGallery to refresh
+            // Force justifiedGallery to refresh.
             refreshTime: 0,
           });
-          // force justifiedGallery to refresh
+          // Force justifiedGallery to refresh.
           gallery.data("jg.controller").startImgAnalyzer();
           fullTabButton.html(
             wrapper.hasClass("fulltab")
@@ -147,39 +157,40 @@ if (!("HSCGjQuery" in window)) {
         fullTabButton.click(() => setFulltab(!wrapper.hasClass("fulltab")));
         filterBar.append(fullTabButton);
         $(document).keyup((e) => {
-          // when ESC is pressed
+          // When ESC is pressed.
           if (e.keyCode === 27) {
             setFulltab(false);
           }
         });
 
         function activateFilterButton(filterButton) {
-          // activate associated filter
+          // Activate associated filter.
           gallery.justifiedGallery({ filter: filterButton.filter });
-          // remove select class from all other selected buttons
+          // Remove select class from all other selected buttons.
           filterBar.find(".selected").removeClass("selected");
           filterButton.addClass("selected");
         }
 
-        // check if the url contains an instruction to apply a specific filter
-        // eg. example.com/images/#gallery-filter=Birds
+        // Check if the url contains an instruction to apply a specific filter,
+        // e.g., example.com/images/#gallery-filter=Birds
         const params = new URLSearchParams(location.hash.replace(/^\#/, ""));
         let activeFilter = params.get("gallery-filter");
         if (!activeFilter) {
-          // default to first filter
+          // Default to first filter.
           activeFilter = options.filterOptions[0].label;
         }
 
-        // create a button for each filter entry
+        // Create a button for each filter entry.
         options.filterOptions.forEach((filterConfig) => {
-          let filter; // create a filter function based on the available attributes of filterConfig
+          let filter; // Create a filter function based on the available attributes of filterConfig.
           if (filterConfig.tags) {
             filter = createTagFilter(filterConfig.tags);
           } else if (filterConfig.rating) {
+            let minMax;
             if (filterConfig.rating.includes("-")) {
-              minMax = filterConfig.rating.split("-"); // e.g. "3-5"
+              minMax = filterConfig.rating.split("-"); // e.g., "3-5"
             } else {
-              minMax = [filterConfig.rating, filterConfig.rating]; // e.g. "4"
+              minMax = [filterConfig.rating, filterConfig.rating]; // e.g., "4"
             }
             filter = createRatingFilter(
               parseInt(minMax[0]),
@@ -190,7 +201,7 @@ if (!("HSCGjQuery" in window)) {
           } else if (filterConfig.description) {
             filter = createImageDescriptionFilter(filterConfig.description);
           } else {
-            // default to always true filter
+            // Default to always true filter.
             filter = createMetadataFilter((meta) => true);
           }
 
@@ -201,7 +212,7 @@ if (!("HSCGjQuery" in window)) {
             activateFilterButton(filterButton);
 
             if (options.storeSelectedFilterInUrl) {
-              // save applied filter in browser url
+              // Save applied filter in browser url.
               const params = new URLSearchParams(
                 location.hash.replace(/^\#/, "")
               );
@@ -222,4 +233,39 @@ if (!("HSCGjQuery" in window)) {
       }
     },
   };
+
+  // We need to wait for the document to be ready, because this script is loaded in the head
+  // and the gallery div is not yet present in the DOM.
+  $(document).ready(function () {
+    // This is the first script that is loaded, so we can be sure that this is the only
+    // gallery script that is running. We can therefore initialize all galleries at once.
+    $(".gallery-wrapper").each(function () {
+      const wrapper = $(this);
+      const optionsElement = wrapper.find(".gallery-options");
+      const options = {
+        galleryId: optionsElement.data("gallery-id"),
+        galleryWrapperId: optionsElement.data("gallery-wrapper-id"),
+        rowHeight: optionsElement.data("row-height"),
+        margins: optionsElement.data("margins"),
+        randomize: optionsElement.data("randomize"),
+        lastRow: optionsElement.data("last-row"),
+        justifiedGalleryParameters: optionsElement.data(
+          "justified-gallery-parameters"
+        ),
+        swipeboxParameters: optionsElement.data("swipebox-parameters"),
+        filterOptions: optionsElement.data("filter-options"),
+        storeSelectedFilterInUrl: optionsElement.data(
+          "store-selected-filter-in-url"
+        ),
+        previewType: optionsElement.data("preview-type"),
+        expandIcon: optionsElement.data("expand-icon"),
+        compressIcon: optionsElement.data("compress-icon"),
+      };
+      window.hugoShortcodeGallery.init(options);
+    });
+  });
+
+  // End of our variable-isolating and self-executing anonymous function.
+  // We call it with the one version of jQuery that was used to load our plugins.
+  // See: http://blog.nemikor.com/2009/10/03/using-multiple-versions-of-jquery/
 })(window.HSCGjQuery);

--- a/assets/shortcode-gallery/gallery.js
+++ b/assets/shortcode-gallery/gallery.js
@@ -1,0 +1,225 @@
+if (!("HSCGjQuery" in window)) {
+  if (!window.jQuery) {
+    throw new Error(
+      "jQuery is not loaded, hugo-shortcode-gallery wont work without it!"
+    );
+  }
+  window.HSCGjQuery = window.jQuery.noConflict(true);
+}
+
+(function ($) {
+  window.hugoShortcodeGallery = {
+    init: function (options) {
+      const wrapper = $("#" + options.galleryWrapperId);
+      const gallery = $("#" + options.galleryId);
+
+      // the instance of swipebox, it will be set once justifiedGallery is initialized
+      let swipeboxInstance = null;
+
+      // before the gallery initialization the listener has to be added
+      // else we can get a race condition and the listener is never called
+      gallery.on("jg.complete", () => {
+        if (options.previewType === "blur" || options.previewType === "color") {
+          $(() => {
+            gallery.find(".lazy").Lazy({
+              visibleOnly: true,
+              afterLoad: (element) => element.removeClass("lazy-blur"),
+            });
+          });
+        }
+
+        swipeboxInstance = gallery
+          .find(".galleryImg")
+          .swipebox($.extend({}, options.swipeboxParameters));
+      });
+
+      // initialize the justified gallery
+      gallery.justifiedGallery(
+        $.extend(
+          {
+            rowHeight: options.rowHeight,
+            margins: options.margins,
+            border: 0,
+            randomize: options.randomize,
+            waitThumbnailsLoad: false,
+            lastRow: options.lastRow,
+            captions: false,
+            filter:
+              options.filterOptions && options.filterOptions.length > 0
+                ? () => false
+                : (e) => e,
+          },
+          options.justifiedGalleryParameters
+        )
+      );
+
+      if (options.filterOptions && options.filterOptions.length > 0) {
+        // this function can be used to create a function that can be used by justifiedGallery
+        // for filtering images by their metadata
+        function createMetadataFilter(filterFunction) {
+          return (entry, index, array) => {
+            let meta = $(entry).find("a").attr("data-meta");
+            meta = meta ? JSON.parse(meta) : {};
+
+            let include = filterFunction(meta);
+
+            // only those images visible in justified gallery should be displayed
+            // in swipebox (only <a> with class galleryImg are displayed in swipebox)
+            $(entry).find("a").toggleClass("galleryImg", include);
+
+            return include;
+          };
+        }
+
+        // this function returns a function that can be used by justifiedGallery
+        // for filtering images by their tags
+        function createTagFilter(tagsRegexString) {
+          const tagsRegex = RegExp(tagsRegexString);
+          return createMetadataFilter((meta) => {
+            let tags = meta.Tags;
+            tags = tags ? tags : [];
+            return tags.some((tag) => tagsRegex.test(tag));
+          });
+        }
+
+        // this function returns a function that can be used by justifiedGallery
+        // for filtering images by their description
+        function createImageDescriptionFilter(descriptionRegexString) {
+          const descriptionRegex = RegExp(descriptionRegexString);
+          return createMetadataFilter((meta) => {
+            let imageDescription = meta.ImageDescription;
+            return (
+              imageDescription !== null &&
+              descriptionRegex.test(imageDescription)
+            );
+          });
+        }
+
+        // this function returns a function that can be used by justifiedGallery
+        // for filtering images by their star rating
+        function createRatingFilter(min, max) {
+          return createMetadataFilter((meta) => {
+            let rating = meta.Rating;
+            if (rating === null) {
+              rating = -1;
+            }
+            return rating >= min && rating <= max;
+          });
+        }
+
+        // this function returns a function that can be used by justifiedGallery
+        // for filtering images by their color labels
+        function createColorLabelFilter(color) {
+          color = color.charAt(0).toLowerCase();
+          return createMetadataFilter((meta) => {
+            let colors = meta.ColorLabels;
+            return colors && colors.includes(color);
+          });
+        }
+
+        // insert a div for inserting filter buttons before the gallery
+        const filterBar = $("<div class='justified-gallery-filterbar'/>");
+        gallery.before(filterBar);
+
+        function setFulltab(activate) {
+          if (activate == wrapper.hasClass("fulltab")) {
+            return; // nothing to do, we are already in the right state
+          }
+
+          wrapper.toggleClass("fulltab");
+          gallery.justifiedGallery({
+            rowHeight: options.rowHeight * (activate ? 1.5 : 1.0),
+            lastRow: activate ? "nojustify" : options.lastRow,
+            // force justifiedGallery to refresh
+            refreshTime: 0,
+          });
+          // force justifiedGallery to refresh
+          gallery.data("jg.controller").startImgAnalyzer();
+          fullTabButton.html(
+            wrapper.hasClass("fulltab")
+              ? options.compressIcon
+              : options.expandIcon
+          );
+        }
+
+        const fullTabButton = $("<button/>");
+        fullTabButton.html(options.expandIcon);
+        fullTabButton.click(() => setFulltab(!wrapper.hasClass("fulltab")));
+        filterBar.append(fullTabButton);
+        $(document).keyup((e) => {
+          // when ESC is pressed
+          if (e.keyCode === 27) {
+            setFulltab(false);
+          }
+        });
+
+        function activateFilterButton(filterButton) {
+          // activate associated filter
+          gallery.justifiedGallery({ filter: filterButton.filter });
+          // remove select class from all other selected buttons
+          filterBar.find(".selected").removeClass("selected");
+          filterButton.addClass("selected");
+        }
+
+        // check if the url contains an instruction to apply a specific filter
+        // eg. example.com/images/#gallery-filter=Birds
+        const params = new URLSearchParams(location.hash.replace(/^\#/, ""));
+        let activeFilter = params.get("gallery-filter");
+        if (!activeFilter) {
+          // default to first filter
+          activeFilter = options.filterOptions[0].label;
+        }
+
+        // create a button for each filter entry
+        options.filterOptions.forEach((filterConfig) => {
+          let filter; // create a filter function based on the available attributes of filterConfig
+          if (filterConfig.tags) {
+            filter = createTagFilter(filterConfig.tags);
+          } else if (filterConfig.rating) {
+            if (filterConfig.rating.includes("-")) {
+              minMax = filterConfig.rating.split("-"); // e.g. "3-5"
+            } else {
+              minMax = [filterConfig.rating, filterConfig.rating]; // e.g. "4"
+            }
+            filter = createRatingFilter(
+              parseInt(minMax[0]),
+              parseInt(minMax[1])
+            );
+          } else if (filterConfig.color_label) {
+            filter = createColorLabelFilter(filterConfig.color_label);
+          } else if (filterConfig.description) {
+            filter = createImageDescriptionFilter(filterConfig.description);
+          } else {
+            // default to always true filter
+            filter = createMetadataFilter((meta) => true);
+          }
+
+          const filterButton = $("<button/>");
+          filterButton.text(filterConfig.label);
+          filterButton.filter = filter;
+          filterButton.click(() => {
+            activateFilterButton(filterButton);
+
+            if (options.storeSelectedFilterInUrl) {
+              // save applied filter in browser url
+              const params = new URLSearchParams(
+                location.hash.replace(/^\#/, "")
+              );
+              params.set("gallery-filter", filterConfig.label);
+              window.history.replaceState(
+                "",
+                "",
+                location.pathname + location.search + "#" + params.toString()
+              );
+            }
+          });
+          filterBar.append(filterButton);
+
+          if (filterConfig.label.toLowerCase() === activeFilter.toLowerCase()) {
+            activateFilterButton(filterButton);
+          }
+        });
+      }
+    },
+  };
+})(window.HSCGjQuery);

--- a/assets/shortcode-gallery/gallery.scss.tpl
+++ b/assets/shortcode-gallery/gallery.scss.tpl
@@ -1,0 +1,13 @@
+{{ with .enlarge }}
+.jg-entry img {
+    transition: transform .25s ease-in-out !important;
+}
+
+.jg-entry img:hover {
+    transform: scale(1.1);
+}
+{{ end }}
+
+.lazy-blur {
+    filter: blur(25px);
+}

--- a/layouts/partials/shortcode-gallery/init.js.html
+++ b/layouts/partials/shortcode-gallery/init.js.html
@@ -1,0 +1,9 @@
+(function($) { $(document).ready(function() { window.hugoShortcodeGallery.init({
+galleryWrapperId: "{{ .galleryWrapperId }}", galleryId: "{{ .galleryId }}",
+rowHeight: {{ .rowHeight }}, margins: {{ .margins }}, randomize: {{ .randomize
+}}, lastRow: "{{ .lastRow }}", justifiedGalleryParameters: {{
+.justifiedGalleryParameters }}, swipeboxParameters: {{ .swipeboxParameters }},
+filterOptions: {{ .filterOptions }}, storeSelectedFilterInUrl: {{
+.storeSelectedFilterInUrl }}, previewType: "{{ .previewType }}", expandIcon: '{{
+.expandIcon }}', compressIcon: '{{ .compressIcon }}' }); });
+})(window.HSCGjQuery);

--- a/layouts/partials/shortcode-gallery/init.js.html
+++ b/layouts/partials/shortcode-gallery/init.js.html
@@ -1,9 +1,0 @@
-(function($) { $(document).ready(function() { window.hugoShortcodeGallery.init({
-galleryWrapperId: "{{ .galleryWrapperId }}", galleryId: "{{ .galleryId }}",
-rowHeight: {{ .rowHeight }}, margins: {{ .margins }}, randomize: {{ .randomize
-}}, lastRow: "{{ .lastRow }}", justifiedGalleryParameters: {{
-.justifiedGalleryParameters }}, swipeboxParameters: {{ .swipeboxParameters }},
-filterOptions: {{ .filterOptions }}, storeSelectedFilterInUrl: {{
-.storeSelectedFilterInUrl }}, previewType: "{{ .previewType }}", expandIcon: '{{
-.expandIcon }}', compressIcon: '{{ .compressIcon }}' }); });
-})(window.HSCGjQuery);

--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -46,15 +46,17 @@
 {{ $thumbnailHoverEffect := .Get "thumbnailHoverEffect" | default (.Site.Params.galleryThumbnailHoverEffect | default "none") }}
 
 <!-- hugos image processing saves images at resources/_gen/images, if the property resourceDir
-	 is changed in hugos config.toml file the images are save <resourceDir>/_gen/images.
-	 Because it is not possible to access the value of resourceDir, users who change resourceDir also have to change
-	[params] resourceDir. -->
+ 	 is changed in hugos config.toml file the images are save <resourceDir>/_gen/images.
+ 	 Because it is not possible to access the value of resourceDir, users who change resourceDir also have to change
+ 	[params] resourceDir. -->
 {{ $thumbnailResourceDir := printf "%s%s" (.Site.Params.resourceDir | default "resources") "/_gen/images/" }}
 
-<!-- Load jquery, jquery-lazy, swipebox and justified_gallery only once per page -->
+{{ $galleryId := (printf "gallery-%v-%v" .Page.File.UniqueID .Ordinal)}}
+{{ $galleryWrapperId := (printf "gallery-%v-%v-wrapper" .Page.File.UniqueID .Ordinal)}}
+
+<!-- Load assets only once per page -->
 {{ if not (.Page.Scratch.Get "galleryLoaded") }}
 	{{ .Page.Scratch.Set "galleryLoaded" true }}
-	<!-- Use relURL to support hugo projects that run in a subdirectory (bug #18) -->
 
 	{{ if $loadJQuery }}
 		<script src="{{ "shortcode-gallery/jquery-3.7.1.min.js" | relURL }}"></script>
@@ -64,36 +66,46 @@
 		<script src="{{ "shortcode-gallery/lazy/jquery.lazy.min.js" | relURL }}"></script>
 	{{ end }}
 
-	<script src="{{ "shortcode-gallery/swipebox/js/jquery.swipebox.min.js" | relURL }}"></script>
-	<link rel="stylesheet" href="{{ "shortcode-gallery/swipebox/css/swipebox.min.css"| relURL }}">
+	<script src="{{ "shortcode-gallery/swipebox/js/jquery.swipebox.min.js" | relURL }}" integrity="sha384-x7SZOzn5sSEEMNqSrAUGhDOSOhM4YmgWgH3X2dzhYGUZEPtECE095pqa3V7Iuvs1" crossorigin="anonymous"></script>
+	<link rel="stylesheet" href="{{ "shortcode-gallery/swipebox/css/swipebox.min.css"| relURL }}" integrity="sha384-TL8XxRhltiGnBQB+n6Ed30t6RCRVE/KTQaQfOOq5n5772120hySFHvi+k203epGT" crossorigin="anonymous" />
 
-	<script src="{{ "shortcode-gallery/justified_gallery/jquery.justifiedGallery.min.js"| relURL }}"></script>
-	<link rel="stylesheet" href="{{ "shortcode-gallery/justified_gallery/justifiedGallery.min.css"| relURL }}"/>
+	<script src="{{ "shortcode-gallery/justified_gallery/jquery.justifiedGallery.min.js"| relURL }}" integrity="sha384-RqjkDw9rLFgzjooqNY42/KTv+s438kLXd/JdZ3Y3hLB6miZFfP8LzKrnijNdsKqz" crossorigin="anonymous"></script>
+	<link rel="stylesheet" href="{{ "shortcode-gallery/justified_gallery/justifiedGallery.min.css"| relURL }}" integrity="sha384-GprljzBtcWkBFDRRRo6fYmlgP/PshDmktYlVR4Qol/hkmfQ9wz/j+GT938+gT3Gb" crossorigin="anonymous" />
+
+	{{ $galleryJs := resources.Get "shortcode-gallery/gallery.js" | resources.Minify | resources.Fingerprint }}
+	<script src="{{ $galleryJs.RelPermalink }}" integrity="{{ $galleryJs.Data.Integrity }}" crossorigin="anonymous"></script>
 {{ end }}
 
-<style>
-	{{ if (eq $thumbnailHoverEffect "enlarge") }}
-		.jg-entry img {
-			transition: transform .25s ease-in-out !important;
-		}
+{{ $cssOptions := (dict "enlarge" (eq $thumbnailHoverEffect "enlarge")) }}
+{{ $galleryCss := resources.Get "shortcode-gallery/gallery.scss.tpl" | resources.ExecuteAsTemplate "shortcode-gallery/gallery.scss" $cssOptions | toCSS | resources.Minify | resources.Fingerprint }}
+<link rel="stylesheet" href="{{ $galleryCss.RelPermalink }}" integrity="{{ $galleryCss.Data.Integrity }}" crossorigin="anonymous" />
 
-		.jg-entry img:hover {
-			transform: scale(1.1);
-		}
-	{{ end }}
+{{ if not (eq $filterOptions "[]") }}
+	{{ $filterbarCss := resources.Get "shortcode-gallery/filterbar.sass" | toCSS | resources.Minify | resources.Fingerprint }}
+	<link rel="stylesheet" href="{{ $filterbarCss.RelPermalink }}" integrity="{{ $filterbarCss.Data.Integrity }}" crossorigin="anonymous" />
+{{ end }}
 
-	{{ if not (eq $filterOptions "[]") }}
-		/* inline css from assets folder */
-		{{ (resources.Get "shortcode-gallery/filterbar.sass" | toCSS).Content | safeCSS }}
-	{{ end }}
-</style>
+{{ $expandIcon := resources.Get "shortcode-gallery/font-awesome/expand-alt-solid.svg" | readFile | safeHTML }}
+{{ $compressIcon := resources.Get "shortcode-gallery/font-awesome/compress-alt-solid.svg" | readFile | safeHTML }}
 
-<!--
-Ordinal increases every time this shortcode is used in a document
-Ordinal: {{ .Ordinal}}
--->
-{{ $galleryId := (printf "gallery-%v-%v" .Page.File.UniqueID .Ordinal)}}
-{{ $galleryWrapperId := (printf "gallery-%v-%v-wrapper" .Page.File.UniqueID .Ordinal)}}
+{{ $initOptions := dict
+	"galleryWrapperId" $galleryWrapperId
+	"galleryId" $galleryId
+	"rowHeight" $rowHeight
+	"margins" $margins
+	"randomize" $randomize
+	"lastRow" (.Get "lastRow" | default (.Site.Params.galleryLastRow | default "justify"))
+	"justifiedGalleryParameters" ($justifiedGalleryParameters | default "{}")
+	"swipeboxParameters" ($swipeboxParameters | default "{}")
+	"filterOptions" ($filterOptions | default "[]")
+	"storeSelectedFilterInUrl" $storeSelectedFilterInUrl
+	"previewType" $previewType
+	"expandIcon" $expandIcon
+	"compressIcon" $compressIcon
+}}
+{{ $initScriptContent := partial "shortcode-gallery/init.js.html" $initOptions }}
+{{ $initScript := resources.FromString (printf "shortcode-gallery/gallery-init-%v.js" .Ordinal) $initScriptContent | resources.Minify | resources.Fingerprint }}
+<script src="{{ $initScript.RelPermalink }}" integrity="{{ $initScript.Data.Integrity }}" crossorigin="anonymous"></script>
 
 <div id="{{ $galleryWrapperId }}" class="gallery-wrapper">
 <div id="{{ $galleryId }}" class="justified-gallery">
@@ -175,13 +187,12 @@ Ordinal: {{ .Ordinal}}
 
 						{{ if (eq $previewType "blur") }}
 							{{ $preview_b := ($thumbnail.Fit ("32x32 q70 box jpg")) }}
-							style="filter: blur(25px);"
 							{{ if $embedPreview }}
 								src="data:image/jpeg;base64,{{ $preview_b.Content | base64Encode }}"
 							{{ else }}
 								src="{{ $preview_b.RelPermalink }}"
 							{{ end }}
-							class="lazy"
+							class="lazy lazy-blur"
 							data-src="{{ $thumbnail.RelPermalink }}"
 						{{ else if (eq $previewType "color") }}
 							{{ $preview_1p := ($thumbnail.Resize ("1x1 box png")) }}
@@ -213,236 +224,3 @@ Ordinal: {{ .Ordinal}}
 </div>
 </div>
 
-<script>
-	if (!("HSCGjQuery" in window)) {
-		if (!window.jQuery) {
-			throw new Error("jQuery is not loaded, hugo-shortcode-gallery wont work without it!");
-		}
-		window.HSCGjQuery = window.jQuery.noConflict(true);
-	}
-
-	// Isolate all our variables from other scripts.
-	// See: https://www.nicoespeon.com/en/2013/05/properly-isolate-variables-in-javascript/
-	// We also expect to get jQuery as a parameter, so that if a second instance of jQuery is loaded
-	// after this script is executed (e.g. by a Hugo theme), we will still be referencing the previous
-	// version of jQuery that has all our plugins loaded.
-	;(function($) {
-
-		$( document ).ready(() => {
-			const gallery = $("#{{ $galleryId }}");
-			{{ $lastRowJustification := .Get "lastRow" | default (.Site.Params.galleryLastRow | default "justify") }}
-
-			// the instance of swipebox, it will be set once justifiedGallery is initialized
-			let swipeboxInstance = null;
-
-			// before the gallery initialization the listener has to be added
-			// else we can get a race condition and the listener is never called
-			gallery.on('jg.complete', () => {
-				{{ if or (eq $previewType "blur") (eq $previewType "color") }}
-					// if there is already some low resolution image data loaded, then we will wait for loading´
-					// the hi-res until the justified gallery has done the layout
-					$(() => {
-						$('.lazy').Lazy({
-							visibleOnly: true,
-							afterLoad: element => element.css({filter: "none", transition: "filter 1.0s ease-in-out"})
-						});
-					});
-				{{ end }}
-
-				swipeboxInstance = $('.galleryImg').swipebox(
-					$.extend({},
-						{ {{ $swipeboxParameters | safeJS }} }
-					)
-				);
-			});
-
-			// initialize the justified gallery
-			gallery.justifiedGallery($.extend(
-				{
-					rowHeight : {{ $rowHeight }},
-					margins : {{ $margins }},
-					border : 0,
-					randomize : {{ $randomize }},
-					waitThumbnailsLoad : false,
-					lastRow : {{ $lastRowJustification }},
-					captions : false,
-					// if there is at least one filter option
-					{{ if not (eq $filterOptions "[]") }}
-						// we first show no images at all
-						// till the code way below selects a filter and applies it
-						// this prevent creating the layout twice
-						filter : () => false
-					{{ end }}
-				},
-				{ {{ $justifiedGalleryParameters | safeJS }} }
-			));
-
-			// only include JS code for filter options if there at least one filter option
-			{{ if not (eq $filterOptions "[]") }}
-
-				// this function can be used to create a function that can be used by justifiedGallery
-				// for filtering images by their metadata
-				function createMetadataFilter(filterFunction) {
-					return (entry, index, array) => {
-						let meta = $(entry).find("a").attr("data-meta");
-						meta = meta ? JSON.parse(meta) : {};
-
-						let include = filterFunction(meta);
-
-						// only those images visible in justified gallery should be displayed
-						// in swipebox (only <a> with class galleryImg are displayed in swipebox)
-						$(entry).find("a").toggleClass("galleryImg", include);
-
-						return include;
-					}
-				}
-
-				// this function returns a function that can be used by justifiedGallery
-				// for filtering images by their tags
-				function createTagFilter(tagsRegexString) {
-					const tagsRegex = RegExp(tagsRegexString);
-					return createMetadataFilter(meta => {
-						let tags = meta.Tags;
-						tags = tags ? tags : [];
-						return tags.some(tag => tagsRegex.test(tag));
-					});
-				};
-
-				// this function returns a function that can be used by justifiedGallery
-				// for filtering images by their description
-				function createImageDescriptionFilter(descriptionRegexString) {
-					const descriptionRegex = RegExp(descriptionRegexString);
-					return createMetadataFilter(meta => {
-						let imageDescription = meta.ImageDescription;
-						return imageDescription !== null && descriptionRegex.test(imageDescription);
-					});
-				};
-
-				// this function returns a function that can be used by justifiedGallery
-				// for filtering images by their star rating
-				function createRatingFilter(min, max) {
-					return createMetadataFilter(meta => {
-						let rating = meta.Rating;
-						if(rating === null){
-							rating = -1;
-						}
-						return rating >= min && rating <= max;
-					});
-				};
-
-				// this function returns a function that can be used by justifiedGallery
-				// for filtering images by their color labels
-				function createColorLabelFilter(color) {
-					color = color.charAt(0).toLowerCase()
-					return createMetadataFilter(meta => {
-						let colors = meta.ColorLabels;
-						return colors && colors.includes(color);
-					});
-				};
-
-
-				const filterOptions = {{ $filterOptions | safeJS }};
-
-				// insert a div for inserting filter buttons before the gallery
-				const filterBar = $("<div class='justified-gallery-filterbar'/>");
-				gallery.before(filterBar);
-
-				var wrapper = document.getElementById("{{ $galleryWrapperId }}");
-
-				// inline svg icons
-				const expandIcon = '{{ (resources.Get "shortcode-gallery/font-awesome/expand-alt-solid.svg").Content | safeHTML }}';
-				const compressIcon = '{{ (resources.Get "shortcode-gallery/font-awesome/compress-alt-solid.svg").Content | safeHTML }}';
-
-				function setFulltab(activate) {
-					if(activate == wrapper.classList.contains("fulltab")){
-						return;  // nothing to do, we are already in the right state
-					}
-
-					wrapper.classList.toggle("fulltab");
-					gallery.justifiedGallery({
-						rowHeight : {{ $rowHeight }} * (activate ? 1.5 : 1.0),
-						lastRow: (activate ? "nojustify": {{ $lastRowJustification }}),
-						// force justifiedGallery to refresh
-						refreshTime: 0,
-					});
-					// force justifiedGallery to refresh
-					gallery.data('jg.controller').startImgAnalyzer();
-					fullTabButton.html(wrapper.classList.contains("fulltab") ? compressIcon : expandIcon)
-				};
-
-				const fullTabButton = $("<button/>");
-				fullTabButton.html(expandIcon);
-				fullTabButton.click(() => setFulltab(!wrapper.classList.contains("fulltab")));
-				filterBar.append(fullTabButton);
-				$(document).keyup(e => {
-					// when ESC is pressed
-					if (e.keyCode === 27){
-						setFulltab(false);
-					}
-				});
-
-				function activateFilterButton(filterButton) {
-					// activate associated filter
-					gallery.justifiedGallery({filter : filterButton.filter});
-					// remove select class from all other selected buttons
-					filterBar.find('.selected').removeClass('selected');
-					filterButton.addClass("selected");
-				};
-
-				// check if the url contains an instruction to apply a specific filter
-				// eg. example.com/images/#gallery-filter=Birds
-				const params = new URLSearchParams(location.hash.replace(/^\#/,""));
-				let activeFilter = params.get('gallery-filter');
-				if (!activeFilter) {
-					// default to first filter
-					activeFilter = filterOptions[0].label;
-				}
-
-				// create a button for each filter entry
-				filterOptions.forEach(filterConfig => {
-					let filter;  // create a filter function based on the available attributes of filterConfig
-					if(filterConfig.tags) {
-						filter = createTagFilter(filterConfig.tags);
-					} else if(filterConfig.rating){
-						if(filterConfig.rating.includes("-")){
-							minMax = filterConfig.rating.split("-");  // e.g. "3-5"
-						} else {
-							minMax = [filterConfig.rating, filterConfig.rating];  // e.g. "4"
-						}
-						filter = createRatingFilter(parseInt(minMax[0]), parseInt(minMax[1]));
-					} else if(filterConfig.color_label){
-						filter = createColorLabelFilter(filterConfig.color_label);
-					} else if(filterConfig.description){
-						filter = createImageDescriptionFilter(filterConfig.description);
-					} else {
-						// default to always true filter
-						filter = createMetadataFilter(meta => true);
-					}
-
-					const filterButton = $("<button/>");
-					filterButton.text(filterConfig.label);
-					filterButton.filter = filter;
-					filterButton.click(() => {
-						activateFilterButton(filterButton);
-
-						{{ if $storeSelectedFilterInUrl }}
-							// save applied filter in browser url
-							const params = new URLSearchParams(location.hash.replace(/^\#/,""));
-							params.set('gallery-filter', filterConfig.label);+
-							window.history.replaceState("", "", location.pathname + location.search + "#" + params.toString());
-						{{ end }}
-					});
-					filterBar.append(filterButton);
-
-					if(filterConfig.label.toLowerCase() === activeFilter.toLowerCase()) {
-						activateFilterButton(filterButton);
-					}
-				});
-			{{ end }}
-		});
-
-	// End of our variable-isolating and self-executing anonymous function.
-	// We call it with the one version of jQuery that was used to load our plugins.
-	// See: http://blog.nemikor.com/2009/10/03/using-multiple-versions-of-jquery/
-	})(window.HSCGjQuery)
-</script>

--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -51,13 +51,6 @@
  	[params] resourceDir. -->
 {{ $thumbnailResourceDir := printf "%s%s" (.Site.Params.resourceDir | default "resources") "/_gen/images/" }}
 
-<!--
-Ordinal increases every time this shortcode is used in a document
-Ordinal: {{ .Ordinal}}
--->
-{{ $galleryId := (printf "gallery-%v-%v" .Page.File.UniqueID .Ordinal)}}
-{{ $galleryWrapperId := (printf "gallery-%v-%v-wrapper" .Page.File.UniqueID .Ordinal)}}
-
 <!-- Load jquery, jquery-lazy, swipebox and justified_gallery only once per page -->
 {{ if not (.Page.Scratch.Get "galleryLoaded") }}
 	{{ .Page.Scratch.Set "galleryLoaded" true }}

--- a/layouts/shortcodes/gallery.html
+++ b/layouts/shortcodes/gallery.html
@@ -51,12 +51,17 @@
  	[params] resourceDir. -->
 {{ $thumbnailResourceDir := printf "%s%s" (.Site.Params.resourceDir | default "resources") "/_gen/images/" }}
 
+<!--
+Ordinal increases every time this shortcode is used in a document
+Ordinal: {{ .Ordinal}}
+-->
 {{ $galleryId := (printf "gallery-%v-%v" .Page.File.UniqueID .Ordinal)}}
 {{ $galleryWrapperId := (printf "gallery-%v-%v-wrapper" .Page.File.UniqueID .Ordinal)}}
 
-<!-- Load assets only once per page -->
+<!-- Load jquery, jquery-lazy, swipebox and justified_gallery only once per page -->
 {{ if not (.Page.Scratch.Get "galleryLoaded") }}
 	{{ .Page.Scratch.Set "galleryLoaded" true }}
+	<!-- Use relURL to support hugo projects that run in a subdirectory (bug #18) -->
 
 	{{ if $loadJQuery }}
 		<script src="{{ "shortcode-gallery/jquery-3.7.1.min.js" | relURL }}"></script>
@@ -66,11 +71,11 @@
 		<script src="{{ "shortcode-gallery/lazy/jquery.lazy.min.js" | relURL }}"></script>
 	{{ end }}
 
-	<script src="{{ "shortcode-gallery/swipebox/js/jquery.swipebox.min.js" | relURL }}" integrity="sha384-x7SZOzn5sSEEMNqSrAUGhDOSOhM4YmgWgH3X2dzhYGUZEPtECE095pqa3V7Iuvs1" crossorigin="anonymous"></script>
-	<link rel="stylesheet" href="{{ "shortcode-gallery/swipebox/css/swipebox.min.css"| relURL }}" integrity="sha384-TL8XxRhltiGnBQB+n6Ed30t6RCRVE/KTQaQfOOq5n5772120hySFHvi+k203epGT" crossorigin="anonymous" />
+	<script src="{{ "shortcode-gallery/swipebox/js/jquery.swipebox.min.js" | relURL }}"></script>
+	<link rel="stylesheet" href="{{ "shortcode-gallery/swipebox/css/swipebox.min.css"| relURL }}">
 
-	<script src="{{ "shortcode-gallery/justified_gallery/jquery.justifiedGallery.min.js"| relURL }}" integrity="sha384-RqjkDw9rLFgzjooqNY42/KTv+s438kLXd/JdZ3Y3hLB6miZFfP8LzKrnijNdsKqz" crossorigin="anonymous"></script>
-	<link rel="stylesheet" href="{{ "shortcode-gallery/justified_gallery/justifiedGallery.min.css"| relURL }}" integrity="sha384-GprljzBtcWkBFDRRRo6fYmlgP/PshDmktYlVR4Qol/hkmfQ9wz/j+GT938+gT3Gb" crossorigin="anonymous" />
+	<script src="{{ "shortcode-gallery/justified_gallery/jquery.justifiedGallery.min.js"| relURL }}"></script>
+	<link rel="stylesheet" href="{{ "shortcode-gallery/justified_gallery/justifiedGallery.min.css"| relURL }}"/>
 
 	{{ $galleryJs := resources.Get "shortcode-gallery/gallery.js" | resources.Minify | resources.Fingerprint }}
 	<script src="{{ $galleryJs.RelPermalink }}" integrity="{{ $galleryJs.Data.Integrity }}" crossorigin="anonymous"></script>
@@ -78,37 +83,39 @@
 
 {{ $cssOptions := (dict "enlarge" (eq $thumbnailHoverEffect "enlarge")) }}
 {{ $galleryCss := resources.Get "shortcode-gallery/gallery.scss.tpl" | resources.ExecuteAsTemplate "shortcode-gallery/gallery.scss" $cssOptions | toCSS | resources.Minify | resources.Fingerprint }}
-<link rel="stylesheet" href="{{ $galleryCss.RelPermalink }}" integrity="{{ $galleryCss.Data.Integrity }}" crossorigin="anonymous" />
+<link rel="stylesheet" href="{{ $galleryCss.RelPermalink }}" integrity="{{ $galleryCss.Data.Integrity }}" crossorigin="anonymous">
 
 {{ if not (eq $filterOptions "[]") }}
 	{{ $filterbarCss := resources.Get "shortcode-gallery/filterbar.sass" | toCSS | resources.Minify | resources.Fingerprint }}
-	<link rel="stylesheet" href="{{ $filterbarCss.RelPermalink }}" integrity="{{ $filterbarCss.Data.Integrity }}" crossorigin="anonymous" />
+	<link rel="stylesheet" href="{{ $filterbarCss.RelPermalink }}" integrity="{{ $filterbarCss.Data.Integrity }}" crossorigin="anonymous">
 {{ end }}
 
-{{ $expandIcon := resources.Get "shortcode-gallery/font-awesome/expand-alt-solid.svg" | readFile | safeHTML }}
-{{ $compressIcon := resources.Get "shortcode-gallery/font-awesome/compress-alt-solid.svg" | readFile | safeHTML }}
-
-{{ $initOptions := dict
-	"galleryWrapperId" $galleryWrapperId
-	"galleryId" $galleryId
-	"rowHeight" $rowHeight
-	"margins" $margins
-	"randomize" $randomize
-	"lastRow" (.Get "lastRow" | default (.Site.Params.galleryLastRow | default "justify"))
-	"justifiedGalleryParameters" ($justifiedGalleryParameters | default "{}")
-	"swipeboxParameters" ($swipeboxParameters | default "{}")
-	"filterOptions" ($filterOptions | default "[]")
-	"storeSelectedFilterInUrl" $storeSelectedFilterInUrl
-	"previewType" $previewType
-	"expandIcon" $expandIcon
-	"compressIcon" $compressIcon
-}}
-{{ $initScriptContent := partial "shortcode-gallery/init.js.html" $initOptions }}
-{{ $initScript := resources.FromString (printf "shortcode-gallery/gallery-init-%v.js" .Ordinal) $initScriptContent | resources.Minify | resources.Fingerprint }}
-<script src="{{ $initScript.RelPermalink }}" integrity="{{ $initScript.Data.Integrity }}" crossorigin="anonymous"></script>
+<!--
+Ordinal increases every time this shortcode is used in a document
+Ordinal: {{ .Ordinal}}
+-->
+{{ $galleryId := (printf "gallery-%v-%v" .Page.File.UniqueID .Ordinal)}}
+{{ $galleryWrapperId := (printf "gallery-%v-%v-wrapper" .Page.File.UniqueID .Ordinal)}}
 
 <div id="{{ $galleryWrapperId }}" class="gallery-wrapper">
-<div id="{{ $galleryId }}" class="justified-gallery">
+	<span
+		class="gallery-options"
+		style="display: none;"
+		data-gallery-id="{{ $galleryId }}"
+		data-gallery-wrapper-id="{{ $galleryWrapperId }}"
+		data-row-height="{{ $rowHeight }}"
+		data-margins="{{ $margins }}"
+		data-randomize="{{ $randomize }}"
+		data-last-row="{{ .Get "lastRow" | default (.Site.Params.galleryLastRow | default "justify") }}"
+		data-justified-gallery-parameters="{{ $justifiedGalleryParameters | default "{}" | jsonify }}"
+		data-swipebox-parameters="{{ $swipeboxParameters | default "{}" | jsonify }}"
+		data-filter-options="{{ $filterOptions | default "[]" }}"
+		data-store-selected-filter-in-url="{{ $storeSelectedFilterInUrl }}"
+		data-preview-type="{{ $previewType }}"
+		data-expand-icon="{{ resources.Get "shortcode-gallery/font-awesome/expand-alt-solid.svg" | readFile | safeHTML }}"
+		data-compress-icon="{{ resources.Get "shortcode-gallery/font-awesome/compress-alt-solid.svg" | readFile | safeHTML }}"
+	></span>
+	<div id="{{ $galleryId }}" class="justified-gallery">
 	{{ range $original := sort $images "Name" $sortOrder}}
 		{{ if eq $original.ResourceType "image" }}
 


### PR DESCRIPTION
...as described [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP#inline_javascript) and [here](https://developer.chrome.com/docs/lighthouse/best-practices/csp-xss/?utm_source=lighthouse&utm_medium=lr#csp_uses_nonces_or_hashes_to_avoid_allowlist_bypasses).

**TL;DR** all inline `<script>` tags and `style` attributes have been moved to resource file imports w/integrity checks.

This is especially nice for folks like me who are setting [Netlify CSP headers](https://docs.netlify.com/routing/headers/#syntax-for-the-netlify-configuration-file) in `netlify.toml` when deploying the Hugo site. I prefer to avoid using `style-src: 'unsafe-inline'` or `script-src: 'unsafe-inline'` since that opens up XSS vulnerabilities.

> Note: Moving forward, integrity sha hashes need to be updated anytime the imported `static/*.css` and `static/*.js` files are updated. This can be done easily by uploading the file [here](https://laysent.github.io/sri-hash-generator/).